### PR TITLE
Ajoute un controle du mode d'automation en rec

### DIFF
--- a/helper_patchers/ReaperQuat.maxpat
+++ b/helper_patchers/ReaperQuat.maxpat
@@ -3,14 +3,14 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 6,
+			"minor" : 0,
 			"revision" : 2,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 34.0, 77.0, 1980.0, 993.0 ],
+		"rect" : [ 34.0, 77.0, 1852.0, 939.0 ],
 		"openrect" : [ 0.0, 0.0, 466.04278028011322, 501.058822154998779 ],
 		"bglocked" : 1,
 		"openinpresentation" : 1,
@@ -38,8 +38,92 @@
 		"tags" : "",
 		"style" : "",
 		"subpatcher_template" : "ManipAliasingSpatial",
-		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
+				"box" : 				{
+					"id" : "obj-142",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 1155.0, 165.0, 29.5, 23.0 ],
+					"text" : "&&"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.823529411764706, 0.788235294117647, 0.647058823529412, 1.0 ],
+					"id" : "obj-132",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1155.0, 135.0, 107.0, 23.0 ],
+					"text" : "v rec_auto_mode"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ],
+					"id" : "obj-85",
+					"linecount" : 2,
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1155.0, 900.0, 220.0, 37.0 ],
+					"text" : "GUIforward mira_toggle_auto_rec recorder::toggle_auto_rec",
+					"varname" : "GUIforward[8]"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
+					"id" : "obj-53",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 960.0, 615.0, 75.0, 35.0 ],
+					"presentation" : 1,
+					"presentation_linecount" : 2,
+					"presentation_rect" : [ 195.0, 240.0, 75.0, 35.0 ],
+					"text" : "AUTO\nREC",
+					"textcolor" : [ 0.20392157137394, 0.596078455448151, 0.858823537826538, 1.0 ],
+					"textjustification" : 1
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"bgcolor" : [ 0.203921568627451, 0.596078431372549, 0.858823529411765, 1.0 ],
+					"checkedcolor" : [ 0.823529411764706, 0.788235294117647, 0.647058823529412, 1.0 ],
+					"id" : "obj-68",
+					"maxclass" : "toggle",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"parameter_enable" : 1,
+					"patching_rect" : [ 945.0, 615.0, 30.0, 30.0 ],
+					"presentation" : 1,
+					"presentation_rect" : [ 180.0, 240.0, 30.0, 30.0 ],
+					"saved_attribute_attributes" : 					{
+						"valueof" : 						{
+							"parameter_shortname" : "toggle[2]",
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "toggle[9]",
+							"parameter_mmax" : 1.0
+						}
+
+					}
+,
+					"varname" : "mira_toggle_auto_rec"
+				}
+
+			}
+, 			{
 				"box" : 				{
 					"id" : "obj-95",
 					"maxclass" : "newobj",
@@ -54,7 +138,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-11",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -63,7 +146,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 105.0, 465.0, 75.0, 21.0 ],
 					"text" : "TO",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -71,7 +154,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-20",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -80,7 +162,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 30.0, 465.0, 75.0, 21.0 ],
 					"text" : "FROM",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -100,12 +182,11 @@
 					"presentation_rect" : [ 105.0, 405.0, 75.0, 75.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "toggle[6]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "toggle[2]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "toggle[6]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -129,12 +210,11 @@
 					"presentation_rect" : [ 30.0, 405.0, 75.0, 75.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "toggle[5]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "toggle[2]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "toggle[5]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -146,7 +226,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-21",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -155,7 +234,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 30.0, 390.0, 150.0, 21.0 ],
 					"text" : "Orientation Control",
-					"textcolor" : [ 0.823529411764706, 0.788235294117647, 0.647058823529412, 1.0 ],
+					"textcolor" : [ 0.823529422283173, 0.788235306739807, 0.647058844566345, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -163,7 +242,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 0.172549019607843, 0.211764705882353, 0.223529411764706, 1.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-178",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -172,7 +250,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 135.0, 375.0, 30.0, 21.0 ],
 					"text" : "0",
-					"textcolor" : [ 0.294117647058824, 0.447058823529412, 0.431372549019608, 1.0 ],
+					"textcolor" : [ 0.294117659330368, 0.447058826684952, 0.431372553110123, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -180,7 +258,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 0.172549019607843, 0.211764705882353, 0.223529411764706, 1.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-177",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -189,7 +266,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 90.0, 375.0, 30.0, 21.0 ],
 					"text" : "0",
-					"textcolor" : [ 0.294117647058824, 0.447058823529412, 0.431372549019608, 1.0 ],
+					"textcolor" : [ 0.294117659330368, 0.447058826684952, 0.431372553110123, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -345,7 +422,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 0.172549019607843, 0.211764705882353, 0.223529411764706, 1.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-123",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -354,7 +430,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 45.0, 375.0, 30.0, 21.0 ],
 					"text" : "0",
-					"textcolor" : [ 0.294117647058824, 0.447058823529412, 0.431372549019608, 1.0 ],
+					"textcolor" : [ 0.294117659330368, 0.447058826684952, 0.431372553110123, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -391,7 +467,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"fontsize" : 12.0,
 					"id" : "obj-144",
 					"maxclass" : "comment",
@@ -399,9 +474,9 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 236.0, 325.0, 30.0, 21.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 270.798892825841904, 298.07161957025528, 45.0, 21.0 ],
+					"presentation_rect" : [ 270.79888916015625, 298.071624755859375, 45.0, 21.0 ],
 					"text" : "x",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -422,12 +497,11 @@
 					"presentation_rect" : [ 285.0, 300.0, 15.0, 15.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "button[17]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "button[5]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "button[17]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -451,7 +525,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-122",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -460,14 +533,13 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 195.0, 140.0, 60.0, 21.0 ],
 					"text" : "Folder",
-					"textcolor" : [ 0.780392156862745, 0.482352941176471, 0.345098039215686, 1.0 ]
+					"textcolor" : [ 0.780392169952393, 0.482352942228317, 0.345098048448563, 1.0 ]
 				}
 
 			}
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-121",
 					"linecount" : 2,
 					"maxclass" : "comment",
@@ -475,9 +547,9 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 360.0, 688.0, 90.0, 35.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 30.0, 140.0, 120.425525993108749, 21.0 ],
+					"presentation_rect" : [ 30.0, 140.0, 120.425529479980469, 21.0 ],
 					"text" : "Save quaternions",
-					"textcolor" : [ 0.780392156862745, 0.482352941176471, 0.345098039215686, 1.0 ]
+					"textcolor" : [ 0.780392169952393, 0.482352942228317, 0.345098048448563, 1.0 ]
 				}
 
 			}
@@ -496,12 +568,11 @@
 					"presentation_rect" : [ 0.0, 138.0, 24.0, 24.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "toggle_play",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "toggle_play",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "toggle_play",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -732,12 +803,11 @@
 					"presentation_rect" : [ 165.0, 135.0, 30.0, 30.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "button[2]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "button[2]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "button[2]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -772,7 +842,7 @@
 					"patching_rect" : [ 2100.0, 195.0, 100.0, 50.0 ],
 					"presentation" : 1,
 					"presentation_linecount" : 2,
-					"presentation_rect" : [ 0.0, 165.0, 285.0, 45.106380760669708 ],
+					"presentation_rect" : [ 0.0, 165.0, 285.0, 45.106380462646484 ],
 					"rounded" : 0.0,
 					"text" : "C:/Users/labsticc/Documents/Manips/Gauthier/Directivité/MaxMSP/headRots/",
 					"textcolor" : [ 0.780392156862745, 0.482352941176471, 0.345098039215686, 1.0 ],
@@ -842,12 +912,11 @@
 					"patching_rect" : [ 1770.0, 135.0, 24.0, 24.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "button[6]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "button[1]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "button[6]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -877,7 +946,7 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 1500.0, 165.0, 154.0, 63.0 ],
 					"text" : "pipe: Evite de se mettre en vitesse au moment pile du marqueur",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -910,7 +979,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-33",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -919,7 +987,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 210.0, 360.0, 75.0, 21.0 ],
 					"text" : "RESET",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -939,11 +1007,10 @@
 					"presentation_rect" : [ 225.0, 285.0, 75.0, 23.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_invisible" : 1,
-							"parameter_longname" : "number[9]",
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "number[9]",
-							"parameter_type" : 3
+							"parameter_type" : 3,
+							"parameter_longname" : "number[9]",
+							"parameter_invisible" : 1
 						}
 
 					}
@@ -956,7 +1023,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-114",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -965,24 +1031,23 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 225.0, 270.0, 75.0, 21.0 ],
 					"text" : "Take",
-					"textcolor" : [ 0.823529411764706, 0.788235294117647, 0.647058823529412, 1.0 ]
+					"textcolor" : [ 0.823529422283173, 0.788235306739807, 0.647058844566345, 1.0 ]
 				}
 
 			}
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"fontsize" : 36.0,
 					"id" : "obj-112",
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 608.292697429656982, 381.951228618621826, 117.0, 54.0 ],
+					"patching_rect" : [ 608.292697429656982, 381.951228618621826, 117.0, 49.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 325.66843968629837, 434.759345591068268, 40.0, 54.0 ],
+					"presentation_rect" : [ 325.668426513671875, 434.75933837890625, 40.0, 49.0 ],
 					"text" : "⟲",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -1000,15 +1065,14 @@
 					"parameter_enable" : 1,
 					"patching_rect" : [ 974.756102561950684, 809.878054857254028, 30.0, 30.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 331.463414669036865, 444.268292903900146, 30.0, 30.0 ],
+					"presentation_rect" : [ 331.463409423828125, 444.268280029296875, 30.0, 30.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "button[8]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "button[5]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "button[8]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -1039,12 +1103,11 @@
 					"presentation_rect" : [ 225.0, 450.0, 105.0, 23.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "Position", "Speed" ],
-							"parameter_longname" : "umenu",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "umenu",
-							"parameter_type" : 2
+							"parameter_enum" : [ "Position", "Speed" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "umenu",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -1137,7 +1200,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"fontsize" : 36.0,
 					"id" : "obj-52",
 					"maxclass" : "comment",
@@ -1147,7 +1209,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 296.5, 298.5, 84.0, 49.0 ],
 					"text" : "-",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -1155,7 +1217,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"fontsize" : 36.0,
 					"id" : "obj-50",
 					"maxclass" : "comment",
@@ -1165,7 +1226,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 296.75, 256.25, 84.0, 49.0 ],
 					"text" : "+",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -1173,17 +1234,16 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"fontsize" : 36.0,
 					"id" : "obj-190",
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 26.27118706703186, 351.694923639297485, 117.0, 54.0 ],
+					"patching_rect" : [ 26.27118706703186, 351.694923639297485, 117.0, 49.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 137.5, 324.0, 40.0, 54.0 ],
+					"presentation_rect" : [ 137.5, 324.0, 40.0, 49.0 ],
 					"text" : "⟲",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -1204,12 +1264,11 @@
 					"presentation_rect" : [ 143.0, 333.5, 30.0, 30.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "button[9]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "button[5]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "button[9]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -1375,12 +1434,11 @@
 					"presentation_rect" : [ 31.0, 337.0, 105.0, 23.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "port COM4", "port COM1" ],
-							"parameter_longname" : "umenu[2]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "umenu[1]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "port COM4", "port COM1" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "umenu[2]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -1414,12 +1472,11 @@
 					"patching_rect" : [ 974.756102561950684, 855.000007152557373, 24.0, 24.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "toggle",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "toggle",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "toggle",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -1469,10 +1526,10 @@
 					"id" : "obj-46",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "int" ],
-					"patching_rect" : [ 1065.0, 135.0, 28.0, 23.0 ],
-					"text" : "t 1"
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "bang" ],
+					"patching_rect" : [ 1065.0, 135.0, 41.0, 23.0 ],
+					"text" : "t 1 b"
 				}
 
 			}
@@ -1509,7 +1566,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1155.243911743164062, 840.365860462188721, 195.0, 37.0 ],
+					"patching_rect" : [ 1155.243911743164063, 840.365860462188721, 195.0, 37.0 ],
 					"text" : "GUIforward mira_umenu_mode controller::radbtn_mode",
 					"varname" : "GUIforward[6]"
 				}
@@ -1523,7 +1580,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1155.243911743164062, 795.243908166885376, 210.0, 37.0 ],
+					"patching_rect" : [ 1155.243911743164063, 795.243908166885376, 210.0, 37.0 ],
 					"text" : "GUIforwardBang mira_btn_reset controller::btn_reset",
 					"varname" : "GUIforward[5]"
 				}
@@ -1627,23 +1684,21 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-25",
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 1035.731713771820068, 795.243908166885376, 90.0, 21.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 225.0, 435.0, 134.756099700927734, 21.0 ],
+					"presentation_rect" : [ 225.0, 435.0, 134.756103515625, 21.0 ],
 					"text" : "Control Mode",
-					"textcolor" : [ 0.823529411764706, 0.788235294117647, 0.647058823529412, 1.0 ]
+					"textcolor" : [ 0.823529422283173, 0.788235306739807, 0.647058844566345, 1.0 ]
 				}
 
 			}
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-19",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -1652,7 +1707,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 105.0, 300.0, 75.0, 21.0 ],
 					"text" : "REC",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -1660,7 +1715,6 @@
 , 			{
 				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
-					"bubble_outlinecolor" : [ 0.701960784313725, 0.701960784313725, 0.701960784313725, 1.0 ],
 					"id" : "obj-13",
 					"maxclass" : "comment",
 					"numinlets" : 1,
@@ -1669,7 +1723,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 30.0, 300.0, 75.0, 21.0 ],
 					"text" : "PLAY",
-					"textcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"textcolor" : [ 0.24705882370472, 0.30588236451149, 0.309803932905197, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -1682,7 +1736,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1155.243911743164062, 750.121955871582031, 147.0, 37.0 ],
+					"patching_rect" : [ 1155.243911743164063, 750.121955871582031, 147.0, 37.0 ],
 					"text" : "GUIforward mira_take recorder::num_take",
 					"varname" : "GUIforward[4]"
 				}
@@ -1696,7 +1750,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1155.243911743164062, 569.634146690368652, 187.0, 37.0 ],
+					"patching_rect" : [ 1155.243911743164063, 569.634146690368652, 187.0, 37.0 ],
 					"text" : "GUIforward mira_toggle_rec recorder::toggle_rec",
 					"varname" : "GUIforward[3]"
 				}
@@ -1710,7 +1764,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1155.243911743164062, 614.756098985671997, 195.0, 37.0 ],
+					"patching_rect" : [ 1155.243911743164063, 614.756098985671997, 195.0, 37.0 ],
 					"text" : "GUIforward mira_toggle_play recorder::toggle_play",
 					"varname" : "GUIforward[2]"
 				}
@@ -1724,7 +1778,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1155.243911743164062, 705.000003576278687, 180.0, 37.0 ],
+					"patching_rect" : [ 1155.243911743164063, 705.000003576278687, 180.0, 37.0 ],
 					"text" : "GUIforward mira_toggle_to controller::toggle_to",
 					"varname" : "GUIforward[1]"
 				}
@@ -1738,7 +1792,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1155.243911743164062, 659.878051280975342, 195.0, 37.0 ],
+					"patching_rect" : [ 1155.243911743164063, 659.878051280975342, 195.0, 37.0 ],
 					"text" : "GUIforward mira_toggle_from controller::toggle_from",
 					"varname" : "GUIforward"
 				}
@@ -1818,15 +1872,14 @@
 					"parameter_enable" : 1,
 					"patching_rect" : [ 1080.853666067123413, 630.609757900238037, 44.736842393875122, 44.736842393875122 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 315.0, 255.0, 44.736842393875122, 44.736842393875122 ],
+					"presentation_rect" : [ 315.0, 255.0, 44.736843109130859, 44.736843109130859 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "button[4]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "button[4]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "button[4]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -1848,15 +1901,14 @@
 					"parameter_enable" : 1,
 					"patching_rect" : [ 1080.853666067123413, 675.731710195541382, 44.736842393875122, 44.736842393875122 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 315.0, 300.0, 44.736842393875122, 44.736842393875122 ],
+					"presentation_rect" : [ 315.0, 300.0, 44.736843109130859, 44.736843109130859 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "button[5]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "button[5]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "button[5]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -1880,12 +1932,11 @@
 					"presentation_rect" : [ 105.0, 240.0, 75.0, 75.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "toggle[3]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "toggle[2]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "toggle[3]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -1909,12 +1960,11 @@
 					"presentation_rect" : [ 30.0, 240.0, 75.0, 75.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "toggle[2]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "toggle[2]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "toggle[2]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -2386,10 +2436,9 @@
 					"enablevscroll" : 0,
 					"id" : "obj-3",
 					"lockeddragscroll" : 0,
-					"lockedsize" : 0,
 					"maxclass" : "bpatcher",
 					"name" : "ReaperRecorder.maxpat",
-					"numinlets" : 6,
+					"numinlets" : 7,
 					"numoutlets" : 3,
 					"offset" : [ 0.0, 0.0 ],
 					"outlettype" : [ "int", "", "" ],
@@ -2410,7 +2459,6 @@
 					"enablevscroll" : 0,
 					"id" : "obj-2",
 					"lockeddragscroll" : 0,
-					"lockedsize" : 0,
 					"maxclass" : "bpatcher",
 					"name" : "YPR_UDP.maxpat",
 					"numinlets" : 4,
@@ -2458,12 +2506,11 @@
 					"presentation_rect" : [ 210.0, 330.0, 75.0, 75.0 ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
-							"parameter_enum" : [ "off", "on" ],
-							"parameter_longname" : "button[7]",
-							"parameter_mmax" : 1,
-							"parameter_modmode" : 0,
 							"parameter_shortname" : "button[5]",
-							"parameter_type" : 2
+							"parameter_enum" : [ "off", "on" ],
+							"parameter_type" : 2,
+							"parameter_longname" : "button[7]",
+							"parameter_mmax" : 1.0
 						}
 
 					}
@@ -2500,7 +2547,7 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 529.0, 253.0, 83.0, 83.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 0.0, 195.0, 285.106368958950043, 29.893616288900375 ],
+					"presentation_rect" : [ 0.0, 195.0, 285.106353759765625, 29.89361572265625 ],
 					"proportion" : 0.5
 				}
 
@@ -2516,7 +2563,7 @@
 					"patching_rect" : [ 765.0, 555.0, 210.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "MIRA GUI",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -2531,7 +2578,7 @@
 					"patching_rect" : [ 990.0, 15.0, 173.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Toggle UDP output",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -2546,7 +2593,7 @@
 					"patching_rect" : [ 765.0, 210.0, 210.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "UDP sends",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -2561,7 +2608,7 @@
 					"patching_rect" : [ 990.0, 225.0, 210.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Serial port selection",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -2612,7 +2659,7 @@
 					"patching_rect" : [ 1485.0, 15.0, 173.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Control mode",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -2645,7 +2692,7 @@
 					"patching_rect" : [ 1290.0, 15.0, 173.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Toggle UDP input",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -2678,7 +2725,7 @@
 					"patching_rect" : [ 765.0, 15.0, 135.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Status checks",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -2726,9 +2773,9 @@
 					"maxclass" : "mira.frame",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 795.487805604934692, 614.756098985671997, 337.582427978515625, 240.00000135600564 ],
+					"patching_rect" : [ 795.48779296875, 614.756103515625, 337.582426071166992, 240.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 31.410254538059235, 240.064088255167007, 337.582427978515625, 240.00000135600564 ],
+					"presentation_rect" : [ 31.410255432128906, 240.0640869140625, 337.582426071166992, 240.0 ],
 					"tabname" : "Recorder"
 				}
 
@@ -2764,7 +2811,7 @@
 					"patching_rect" : [ 1680.0, 15.0, 150.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "quat points recording",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -2789,7 +2836,7 @@
  ],
 		"lines" : [ 			{
 				"patchline" : 				{
-					"destination" : [ "obj-3", 5 ],
+					"destination" : [ "obj-3", 6 ],
 					"source" : [ "obj-100", 0 ]
 				}
 
@@ -2915,6 +2962,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-142", 1 ],
+					"source" : [ "obj-132", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-125", 0 ],
 					"source" : [ "obj-133", 0 ]
 				}
@@ -2938,6 +2992,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-292", 0 ],
 					"source" : [ "obj-140", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-54", 0 ],
+					"source" : [ "obj-142", 0 ]
 				}
 
 			}
@@ -3355,7 +3416,14 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-54", 0 ],
+					"destination" : [ "obj-132", 0 ],
+					"source" : [ "obj-46", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-142", 0 ],
 					"source" : [ "obj-46", 0 ]
 				}
 

--- a/helper_patchers/ReaperRecorder.maxpat
+++ b/helper_patchers/ReaperRecorder.maxpat
@@ -3,14 +3,14 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 6,
+			"minor" : 0,
 			"revision" : 2,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 35.0, 78.0, 1474.0, 993.0 ],
+		"rect" : [ 34.0, 77.0, 1362.0, 939.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 1,
 		"default_fontsize" : 12.0,
@@ -37,8 +37,156 @@
 		"tags" : "",
 		"style" : "",
 		"subpatcher_template" : "ManipAliasingSpatial",
-		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
+				"box" : 				{
+					"annotation" : "Automation mode while recording. 0: Read ; 1: Write",
+					"comment" : "Automation mode while recording. 0: Read ; 1: Write",
+					"hint" : "Automation mode while recording. 0: Read ; 1: Write",
+					"id" : "obj-103",
+					"index" : 6,
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1050.0, 600.0, 30.0, 30.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-102",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 990.0, 660.0, 74.0, 23.0 ],
+					"text" : "loadmess 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.823529411764706, 0.788235294117647, 0.647058823529412, 1.0 ],
+					"id" : "obj-101",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 990.0, 720.0, 107.0, 23.0 ],
+					"text" : "v rec_auto_mode"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
+					"id" : "obj-98",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1050.0, 675.0, 48.0, 35.0 ],
+					"presentation" : 1,
+					"presentation_rect" : [ 38.571426391601563, 75.274726867675781, 105.0, 21.0 ],
+					"text" : "write auto",
+					"textcolor" : [ 0.780392169952393, 0.482352942228317, 0.345098048448563, 1.0 ],
+					"textjustification" : 1
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"bgcolor" : [ 0.2, 0.2, 0.2, 0.0 ],
+					"checkedcolor" : [ 0.780392156862745, 0.482352941176471, 0.345098039215686, 1.0 ],
+					"id" : "obj-100",
+					"maxclass" : "toggle",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 1005.0, 690.0, 24.0, 24.0 ],
+					"presentation" : 1,
+					"presentation_rect" : [ 79.071426391601563, 60.274726867675781, 24.0, 24.0 ],
+					"uncheckedcolor" : [ 0.294117647058824, 0.447058823529412, 0.431372549019608, 1.0 ],
+					"varname" : "toggle_auto_rec"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-94",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"patching_rect" : [ 930.0, 690.0, 28.0, 23.0 ],
+					"text" : "t b"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-84",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "" ],
+					"patching_rect" : [ 900.0, 660.0, 41.0, 23.0 ],
+					"text" : "sel 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.294117647058824, 0.447058823529412, 0.431372549019608, 1.0 ],
+					"id" : "obj-68",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 900.0, 600.0, 101.0, 23.0 ],
+					"text" : "r #0rec_auto"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.682352941176471, 0.364705882352941, 0.250980392156863, 1.0 ],
+					"id" : "obj-67",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 930.0, 750.0, 101.0, 23.0 ],
+					"text" : "s #0autoRead"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.682352941176471, 0.364705882352941, 0.250980392156863, 1.0 ],
+					"id" : "obj-19",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 900.0, 780.0, 107.0, 23.0 ],
+					"text" : "s #0autoWrite"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.823529411764706, 0.788235294117647, 0.647058823529412, 1.0 ],
+					"id" : "obj-6",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 900.0, 630.0, 107.0, 23.0 ],
+					"text" : "v rec_auto_mode"
+				}
+
+			}
+, 			{
 				"box" : 				{
 					"id" : "obj-3",
 					"maxclass" : "newobj",
@@ -49,13 +197,14 @@
 					"restore" : 					{
 						"btn_clearTake" : [ 0.0 ],
 						"deleteTakeActionID" : [ "_0a651235823b6a4eb6cf849176b974be" ],
+						"toggle_auto_rec" : [ 0 ],
 						"toggle_play" : [ 0 ],
 						"toggle_rec" : [ 0 ],
 						"toggle_rec[1]" : [ 0 ]
 					}
 ,
 					"text" : "autopattr",
-					"varname" : "u036005626"
+					"varname" : "u624000896"
 				}
 
 			}
@@ -69,9 +218,9 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 231.176480233669281, 80.588238656520844, 60.0, 35.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 195.882361114025116, 99.294118076562881, 89.411768436431885, 21.0 ],
+					"presentation_rect" : [ 195.882354736328125, 99.294120788574219, 89.411766052246094, 21.0 ],
 					"text" : "clearTake ID",
-					"textcolor" : [ 0.294117647058824, 0.447058823529412, 0.431372549019608, 1.0 ],
+					"textcolor" : [ 0.294117659330368, 0.447058826684952, 0.431372553110123, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -115,7 +264,7 @@
 					"patching_rect" : [ 765.0, 255.0, 150.000006258487701, 45.0 ],
 					"presentation" : 1,
 					"presentation_linecount" : 2,
-					"presentation_rect" : [ 0.0, 99.5, 195.29412579536438, 20.588236153125763 ],
+					"presentation_rect" : [ 0.0, 99.5, 195.29412841796875, 20.588235855102539 ],
 					"rounded" : 0.0,
 					"text" : "_0a651235823b6a4eb6cf849176b974be",
 					"textcolor" : [ 0.294117647058824, 0.447058823529412, 0.431372549019608, 1.0 ],
@@ -130,7 +279,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 915.0, 750.0, 107.0, 23.0 ],
+					"patching_rect" : [ 1155.0, 645.0, 107.0, 23.0 ],
 					"text" : "s #0clearTake"
 				}
 
@@ -143,11 +292,11 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 960.0, 705.0, 48.0, 35.0 ],
+					"patching_rect" : [ 1200.0, 600.0, 48.0, 35.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 120.0, 76.5, 75.0, 21.0 ],
+					"presentation_rect" : [ 210.0, 76.5, 75.0, 21.0 ],
 					"text" : "clear take",
-					"textcolor" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
+					"textcolor" : [ 0.631372570991516, 0.278431385755539, 0.180392161011696, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -163,9 +312,9 @@
 					"outlettype" : [ "bang" ],
 					"outlinecolor" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 915.0, 705.0, 24.0, 24.0 ],
+					"patching_rect" : [ 1155.0, 600.0, 24.0, 24.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 90.0, 75.0, 24.0, 24.0 ],
+					"presentation_rect" : [ 180.0, 75.0, 24.0, 24.0 ],
 					"varname" : "btn_clearTake"
 				}
 
@@ -340,8 +489,8 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 720.0, 720.0, 107.0, 23.0 ],
-					"text" : "s #0autoWrite"
+					"patching_rect" : [ 720.0, 720.0, 101.0, 23.0 ],
+					"text" : "s #0rec_auto"
 				}
 
 			}
@@ -1027,7 +1176,6 @@
 					"enablevscroll" : 0,
 					"id" : "obj-70",
 					"lockeddragscroll" : 0,
-					"lockedsize" : 0,
 					"maxclass" : "bpatcher",
 					"name" : "UDPSender.maxpat",
 					"numinlets" : 2,
@@ -1073,7 +1221,7 @@
 					"comment" : "Automation mode. 0: Latch Preview 1: Read 2: Write",
 					"hint" : "Automation mode. 0: Latch Preview 1: Read 2: Write",
 					"id" : "obj-54",
-					"index" : 6,
+					"index" : 7,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -1150,7 +1298,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 960.0, 630.0, 60.0, 35.0 ],
+					"patching_rect" : [ 1200.0, 525.0, 60.0, 35.0 ],
 					"presentation" : 1,
 					"presentation_linecount" : 2,
 					"presentation_rect" : [ 120.0, 30.0, 60.0, 35.0 ],
@@ -1172,7 +1320,7 @@
 					"numoutlets" : 2,
 					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 900.0, 630.0, 50.0, 23.0 ],
+					"patching_rect" : [ 1140.0, 525.0, 50.0, 23.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 120.0, 0.0, 60.0, 23.0 ],
 					"textcolor" : [ 0.294117647058824, 0.447058823529412, 0.431372549019608, 1.0 ],
@@ -1188,7 +1336,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 960.0, 585.0, 45.0, 21.0 ],
+					"patching_rect" : [ 1200.0, 480.0, 45.0, 21.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 180.0, 30.0, 60.0, 21.0 ],
 					"text" : "take",
@@ -1208,7 +1356,7 @@
 					"numoutlets" : 2,
 					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 900.0, 585.0, 50.0, 23.0 ],
+					"patching_rect" : [ 1140.0, 480.0, 50.0, 23.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 180.0, 0.0, 50.0, 23.0 ],
 					"textcolor" : [ 0.294117647058824, 0.447058823529412, 0.431372549019608, 1.0 ],
@@ -1471,6 +1619,40 @@
 				"box" : 				{
 					"background" : 1,
 					"fontface" : 1,
+					"id" : "obj-4",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 885.0, 555.0, 195.0, 35.0 ],
+					"suppressinlet" : 1,
+					"text" : "Automation mode while recording",
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"angle" : 270.0,
+					"background" : 1,
+					"bgcolor" : [ 0.549019607843137, 0.670588235294118, 0.631372549019608, 1.0 ],
+					"border" : 1,
+					"bordercolor" : [ 0.996078431372549, 0.996078431372549, 0.996078431372549, 1.0 ],
+					"id" : "obj-5",
+					"maxclass" : "panel",
+					"mode" : 0,
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 885.0, 555.0, 225.0, 255.0 ],
+					"proportion" : 0.5,
+					"prototypename" : "backgroundPanel"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"fontface" : 1,
 					"id" : "obj-1",
 					"linecount" : 4,
 					"maxclass" : "comment",
@@ -1479,7 +1661,7 @@
 					"patching_rect" : [ 735.0, 120.0, 210.0, 63.0 ],
 					"suppressinlet" : 1,
 					"text" : "Clear take: custom Reaper action that requires external packages (see doc on Google Drive)",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1512,7 +1694,7 @@
 					"patching_rect" : [ 405.0, 555.0, 135.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Play/Stop backend",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1542,10 +1724,10 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 885.0, 555.0, 135.0, 21.0 ],
+					"patching_rect" : [ 1125.0, 450.0, 135.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "take GUI",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1561,7 +1743,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 885.0, 555.0, 165.0, 255.0 ],
+					"patching_rect" : [ 1125.0, 450.0, 165.0, 255.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -1581,7 +1763,7 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 270.0, 15.0, 120.0, 30.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 0.0, 0.0, 285.294129550457001, 120.0 ],
+					"presentation_rect" : [ 0.0, 0.0, 285.29412841796875, 120.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -1598,7 +1780,7 @@
 					"patching_rect" : [ 960.0, 210.0, 285.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Automation mode : see Reaper actions IDs",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1631,7 +1813,7 @@
 					"patching_rect" : [ 960.0, 15.0, 75.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "UDP sends",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1664,7 +1846,7 @@
 					"patching_rect" : [ 405.0, 300.0, 135.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Take backend",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1679,7 +1861,7 @@
 					"patching_rect" : [ 405.0, 120.0, 135.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Take frontend",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1694,7 +1876,7 @@
 					"patching_rect" : [ 15.0, 300.0, 135.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Play/Stop bitstate",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1763,7 +1945,7 @@
 					"patching_rect" : [ 15.0, 15.0, 135.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Play/Stop frontend",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1778,7 +1960,7 @@
 					"patching_rect" : [ 15.0, 555.0, 135.0, 21.0 ],
 					"suppressinlet" : 1,
 					"text" : "Refresh UI",
-					"textcolor" : [ 0.341176470588235, 0.282352941176471, 0.32156862745098, 1.0 ]
+					"textcolor" : [ 0.341176480054855, 0.282352954149246, 0.321568638086319, 1.0 ]
 				}
 
 			}
@@ -1820,6 +2002,36 @@
 			}
  ],
 		"lines" : [ 			{
+				"patchline" : 				{
+					"destination" : [ "obj-101", 0 ],
+					"source" : [ "obj-100", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-100", 0 ],
+					"order" : 0,
+					"source" : [ "obj-102", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-101", 0 ],
+					"order" : 1,
+					"source" : [ "obj-102", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-100", 0 ],
+					"source" : [ "obj-103", 0 ]
+				}
+
+			}
+, 			{
 				"patchline" : 				{
 					"destination" : [ "obj-23", 0 ],
 					"source" : [ "obj-11", 0 ]
@@ -2350,6 +2562,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-84", 0 ],
+					"source" : [ "obj-6", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-56", 0 ],
 					"source" : [ "obj-60", 0 ]
 				}
@@ -2373,6 +2592,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-81", 0 ],
 					"source" : [ "obj-65", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-6", 0 ],
+					"source" : [ "obj-68", 0 ]
 				}
 
 			}
@@ -2478,6 +2704,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-19", 0 ],
+					"source" : [ "obj-84", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-94", 0 ],
+					"source" : [ "obj-84", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-76", 0 ],
 					"source" : [ "obj-85", 0 ]
 				}
@@ -2524,6 +2764,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-90", 0 ],
 					"source" : [ "obj-91", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-67", 0 ],
+					"source" : [ "obj-94", 0 ]
 				}
 
 			}


### PR DESCRIPTION
Le toggle `auto rec` permet d'enregistrer ou non les automations lors de l'enregistrement.
- Pour la prise originale (locuteur avec T3 sur la tête) : activer le toggle pour écrire les mouvements sur Reaper.
- Pour la reproduction (PMX4 avec T3 fixée dessus) : désactiver le toggle pour lire les automations de mouvement tout en écrivant un nouveau fichier de HeadRot (sert à la comparaison des mouvements).

resolve #7 